### PR TITLE
Support Account Fields

### DIFF
--- a/activitypub/inbox.go
+++ b/activitypub/inbox.go
@@ -420,8 +420,9 @@ func (i *inboxProcessor) processUpdateActor(update map[string]any) error {
 	actor.Note = stringFromAny(update["summary"])
 	actor.Avatar = stringFromAny(mapFromAny(update["icon"])["url"])
 	actor.Header = stringFromAny(mapFromAny(update["image"])["url"])
-	actor.Attachments = anyToSlice(update["attachment"])
 	actor.PublicKey = []byte(stringFromAny(mapFromAny(update["publicKey"])["publicKeyPem"]))
+
+	// todo update attributes
 
 	return i.db.Save(&actor).Error
 }

--- a/automigrate.go
+++ b/automigrate.go
@@ -15,7 +15,7 @@ func (a *AutoMigrateCmd) Run(ctx *Context) error {
 	}
 
 	return db.AutoMigrate(
-		&models.Actor{},
+		&models.Actor{}, &models.ActorAttribute{},
 		&models.Account{}, &models.AccountList{}, &models.AccountListMember{}, &models.AccountRole{}, &models.AccountMarker{},
 		&models.Application{},
 		&models.Conversation{},

--- a/internal/models/actor.go
+++ b/internal/models/actor.go
@@ -23,10 +23,10 @@ type Actor struct {
 	FollowingCount int32  `gorm:"default:0;not null"`
 	StatusesCount  int32  `gorm:"default:0;not null"`
 	LastStatusAt   time.Time
-	Avatar         string `gorm:"size:255"`
-	Header         string `gorm:"size:255"`
-	PublicKey      []byte `gorm:"type:blob;not null"`
-	Attachments    []any  `gorm:"type:text;serializer:json"`
+	Avatar         string            `gorm:"size:255"`
+	Header         string            `gorm:"size:255"`
+	PublicKey      []byte            `gorm:"type:blob;not null"`
+	Attributes     []*ActorAttribute `gorm:"constraint:OnDelete:CASCADE;"`
 }
 
 func (a *Actor) Acct() string {
@@ -58,6 +58,13 @@ func (a *Actor) PublicKeyID() string {
 
 func (a *Actor) URL() string {
 	return fmt.Sprintf("https://%s/@%s", a.Domain, a.Name)
+}
+
+type ActorAttribute struct {
+	ID      uint32 `gorm:"primarykey"`
+	ActorID snowflake.ID
+	Name    string `gorm:"size:255;not null"`
+	Value   string `gorm:"type:text;not null"`
 }
 
 type Actors struct {

--- a/mastodon/accounts.go
+++ b/mastodon/accounts.go
@@ -19,7 +19,7 @@ func AccountsShow(env *Env, w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 	var actor models.Actor
-	if err := env.DB.First(&actor, chi.URLParam(r, "id")).Error; err != nil {
+	if err := env.DB.Preload("Attributes").Take(&actor, chi.URLParam(r, "id")).Error; err != nil {
 		return httpx.Error(http.StatusNotFound, err)
 	}
 	return to.JSON(w, serialiseAccount(&actor))

--- a/mastodon/serialisers.go
+++ b/mastodon/serialisers.go
@@ -34,7 +34,13 @@ type Account struct {
 	LastStatusAt   *string          `json:"last_status_at"`
 	NoIndex        bool             `json:"noindex"` // default false
 	Emojis         []map[string]any `json:"emojis"`
-	Fields         []map[string]any `json:"fields"`
+	Fields         []Field          `json:"fields"`
+}
+
+type Field struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+	// TODO verified_at
 }
 
 type CredentialAccount struct {
@@ -90,7 +96,12 @@ func serialiseAccount(a *models.Actor) *Account {
 			return &st
 		}(),
 		Emojis: make([]map[string]any, 0), // must be an empty array -- not null
-		Fields: make([]map[string]any, 0), // ditto
+		Fields: algorithms.Map(a.Attributes, func(a *models.ActorAttribute) Field {
+			return Field{
+				Name:  a.Name,
+				Value: a.Value,
+			}
+		}),
 	}
 }
 


### PR DESCRIPTION
Add support for freetext account.fields. These come from the PropertyValue attachments on ActivityPub profiles and are stored in actor_attributes.

It seems that most times we can get away without including them in the response; so at the moment they are only returned on accounts#show.