### PR TITLE
fix content-type for get

### DIFF
--- a/activitypub/client.go
+++ b/activitypub/client.go
@@ -184,7 +184,7 @@ func (c *Client) Fetch(uri string, obj interface{}) error {
 	return requests.URL(uri).
 		Accept(`application/ld+json; profile="https://www.w3.org/ns/activitystreams"`).
 		Transport(c).
-		CheckContentType(`application/ld+json; profile="https://www.w3.org/ns/activitystreams"`, "application/activity+json", "application/json").
+		CheckContentType("application/ld+json", "application/activity+json", "application/json").
 		CheckStatus(http.StatusOK).
 		ToJSON(obj).
 		Fetch(c.ctx)


### PR DESCRIPTION
Requests uses mime.ParseMediaType which, correctly, returns the media type without the optional parameters. Therefore CheckContentType parameters should be plain media types.