### PR TITLE
specify foreignKey

### DIFF
--- a/models/instance.go
+++ b/models/instance.go
@@ -18,7 +18,7 @@ type Instance struct {
 	UpdatedAt        time.Time
 	Domain           string `gorm:"size:64;uniqueIndex"`
 	AdminID          *snowflake.ID
-	Admin            *Account `gorm:"constraint:OnDelete:CASCADE;<-:create;"` // the admin account for this instance
+	Admin            *Account `gorm:"foreignKey:AdminID;constraint:OnDelete:CASCADE;<-:create;"` // the admin account for this instance
 	SourceURL        string
 	Title            string `gorm:"size:64"`
 	ShortDescription string

--- a/models/relationship.go
+++ b/models/relationship.go
@@ -13,7 +13,7 @@ type Relationship struct {
 	ActorID    snowflake.ID `gorm:"primarykey;autoIncrement:false"`
 	Actor      *Actor       `gorm:"constraint:OnDelete:CASCADE;<-:false;"`
 	TargetID   snowflake.ID `gorm:"primarykey;autoIncrement:false"`
-	Target     *Actor       `gorm:"constraint:OnDelete:CASCADE;<-:false;"`
+	Target     *Actor       `gorm:"foreignKey:TargetID;constraint:OnDelete:CASCADE;<-:false;"`
 	Muting     bool         `gorm:"not null;default:false"`
 	Blocking   bool         `gorm:"not null;default:false"`
 	BlockedBy  bool         `gorm:"not null;default:false"`

--- a/models/status.go
+++ b/models/status.go
@@ -32,7 +32,7 @@ type Status struct {
 	ReblogsCount     int        `gorm:"not null;default:0"`
 	FavouritesCount  int        `gorm:"not null;default:0"`
 	ReblogID         *snowflake.ID
-	Reblog           *Status             `gorm:"constraint:OnDelete:CASCADE;<-:false;"` // don't update reblog on status update
+	Reblog           *Status             `gorm:"foreignKey:ReblogID;constraint:OnDelete:CASCADE;<-:false;"` // don't update reblog on status update
 	Reaction         *Reaction           `gorm:"constraint:OnDelete:CASCADE;<-:false;"` // don't update reaction on status update
 	Attachments      []*StatusAttachment `gorm:"constraint:OnDelete:CASCADE;"`
 	Mentions         []StatusMention     `gorm:"constraint:OnDelete:CASCADE;"`


### PR DESCRIPTION
When it is not named after [the owner’s type name plus its primary field name](https://gorm.io/docs/belongs_to.html#Override-Foreign-Key).

Fixes #18.